### PR TITLE
feat: force less wide ranking charts on mobile

### DIFF
--- a/results/src/core/charts/ChartContainer.js
+++ b/results/src/core/charts/ChartContainer.js
@@ -90,9 +90,10 @@ const Container = styled.div`
 const ChartContainerInner = styled.div`
     &.ChartContainerInner--expand {
         @media ${mq.small} {
-            /* max-height: 400px; */
+          min-width:500px;
         }
-        @media ${mq.smallMedium} {
+        @media ${mq.medium} {
+            max-width: auto;
             min-width: 800px;
             padding-bottom: ${spacing(1)};
         }


### PR DESCRIPTION
![Selection_999(237)](https://user-images.githubusercontent.com/41970/144450875-b95810f6-b114-49a3-8eea-d5387096fbc7.png)

We can further tweak the exact value later since I'd also like to move the sidebar to the top on mobile, but 500px seems fine. There's nothing wrong with scrolling horizontally there, we should just not make people scroll unnecessarily .