### PR TITLE
feat: set minimum font size to 12px

### DIFF
--- a/results/surveys/css2021/theme/typography.ts
+++ b/results/surveys/css2021/theme/typography.ts
@@ -7,7 +7,7 @@ const stateOfCSSThemeTypography: DefaultTheme['typography'] = {
         desktop: '17px',
     },
     size: {
-        smaller: '0.7rem',
+        smaller: '0.75rem',
         small: '0.8rem',
         smallish: '0.9rem',
         medium: '1rem',


### PR DESCRIPTION
This sets the minimum font size to 12px instead of 11.something. (12 really is the bare minimum)