### PR TITLE
Fix award winner links

### DIFF
--- a/results/src/core/blocks/awards/AwardBlock.js
+++ b/results/src/core/blocks/awards/AwardBlock.js
@@ -90,7 +90,7 @@ const AwardBlock = ({ block }) => {
 
 const EntityItem = ({ entity }) => {
     const { name, homepage, mdn } = entity
-    const url = homepage || (mdn && `https://developer.mozilla.org${mdn.url}`)
+    const url = homepage.url || (mdn && `https://developer.mozilla.org${mdn.url}`)
     return url ? <a href={url}>{name}</a> : <span>{name}</span>
 }
 


### PR DESCRIPTION
Before:

https://2021.stateofcss.com/en-US/awards/[object%20Object]

After

https://postcss.org/

cc @SachaG 