### PR TITLE
Use dark UI appearance

### DIFF
--- a/results/src/core/theme/GlobalStyle.ts
+++ b/results/src/core/theme/GlobalStyle.ts
@@ -26,6 +26,7 @@ export const GlobalStyle = createGlobalStyle`
     
     html {
         box-sizing: border-box;
+        color-scheme: dark;
     }
     
     *,


### PR DESCRIPTION
Since the site is done in dark tones, it probably makes sense to make the browser/native UI in the corresponding colors.
Such sharp contrast (light native UI components and dark colors throughout the site) hurts your eyes. 

Before:

![image](https://user-images.githubusercontent.com/4408379/145897309-0b8a909c-c907-48cd-9411-3d1b035fd98a.png)

After:

![image](https://user-images.githubusercontent.com/4408379/145897369-f12a97cd-be68-4f6f-afb4-7e884c0963ea.png)
