### PR TITLE
Make narrower Share Options block

### DIFF
--- a/results/src/core/share/ShareLink.js
+++ b/results/src/core/share/ShareLink.js
@@ -66,6 +66,7 @@ const Label = styled.span`
 `
 
 const Icon = styled.span`
+    display: flex;
     margin-right: ${spacing()};
 `
 


### PR DESCRIPTION
Then sharing icons will also be vertically aligned to the center.

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/145898806-654e1293-dc40-469f-b9dc-52b9d5d22ac6.png) |  ![image](https://user-images.githubusercontent.com/4408379/145898666-6db4e5e9-e364-451b-8c6b-b46a3bb91fc2.png)|





