### PR TITLE
Fix undefined npm links

### DIFF
--- a/api/src/resolvers/entities.ts
+++ b/api/src/resolvers/entities.ts
@@ -65,6 +65,10 @@ export default {
             return { name: entity.caniuse, url: `https://caniuse.com/${entity.caniuse}` }
         },
         npm: async (entity: Entity, args: any, { db }: RequestContext) => {
+            if (!entity || !entity.npm) {
+                return
+            }
+                        
             return { name: entity.npm, url: `https://www.npmjs.com/package/${entity.npm}` }
         }
     }


### PR DESCRIPTION
As one example - https://2021.stateofcss.com/en-us/technologies/css-in-js/

![image](https://user-images.githubusercontent.com/4408379/145901441-3a937d72-e63f-419e-9a69-95bc9c39701b.png)


NPM link leads to https://www.npmjs.com/package/undefined