### PR TITLE
Various TickItem improvements

### DIFF
--- a/results/src/core/charts/generic/TickItem.tsx
+++ b/results/src/core/charts/generic/TickItem.tsx
@@ -48,13 +48,16 @@ export const Text = ({
         textProps.textAnchor = 'start'
     }
 
-    const component = (
-        <text {...textProps}>
-            <title>{description ?? label}</title>
-            {shortLabel ?? label}
-        </text>
+    const component = <text {...textProps}>{shortLabel ?? label}</text>
+
+    return (
+        <TooltipComponent
+            trigger={component}
+            contents={description ?? label}
+            asChild={true}
+            clickable={hasLink}
+        />
     )
-    return <TooltipComponent trigger={component} contents={description ?? label} asChild={true} />
 }
 
 export const getBucketLabel = args => {

--- a/results/src/core/components/Tooltip.js
+++ b/results/src/core/components/Tooltip.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { fontSize, spacing } from 'core/theme'
 
 import * as Tooltip from '@radix-ui/react-tooltip'
@@ -18,9 +18,16 @@ const Content = styled(Tooltip.Content)`
 const Trigger = styled(Tooltip.Trigger)`
     background: none;
     border: none;
-    cursor: pointer;
     padding: 0;
     display: inline-block;
+
+    ${props => {
+        if (props.$clickable) {
+            return css`
+                cursor: pointer;
+            `
+        }
+    }}
 `
 
 const Arrow = styled(Tooltip.Arrow)`
@@ -29,9 +36,11 @@ const Arrow = styled(Tooltip.Arrow)`
     stroke-width: 2px;
 `
 
-const Tip = ({ trigger, contents, asChild = true }) => (
+const Tip = ({ trigger, contents, asChild = true, clickable = false }) => (
     <Tooltip.Root delayDuration={200}>
-        <Trigger asChild={asChild}>{trigger}</Trigger>
+        <Trigger asChild={asChild} $clickable={clickable}>
+            {trigger}
+        </Trigger>
         <Content side="top">
             {contents}
             {/* <Arrow /> */}


### PR DESCRIPTION

1. Remove native title

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/146003902-95eee298-cec1-4d28-a2e4-e7675e4f5995.png) | ![image](https://user-images.githubusercontent.com/4408379/146003670-ff322c8f-0201-446c-b65e-ffe5713675c3.png) |

2. Make clickable only those items that have a link

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/146004433-1eb1cad2-4b3f-4a0c-885e-fdb5bd1b8f2c.png)| ![image](https://user-images.githubusercontent.com/4408379/146004529-99a57e5e-6cf8-42f6-b463-48c3155fa607.png) |

cc @SachaG 




