### PR TITLE
Add small gap between sharing items in modal

### DIFF
--- a/results/src/core/blocks/block/BlockShare.js
+++ b/results/src/core/blocks/block/BlockShare.js
@@ -21,7 +21,7 @@ const Share = styled.div`
 
     @media ${mq.mediumLarge} {
         display: grid;
-        gap: 0;
+        gap: 1rem;
         grid-template-columns: 500px 1fr;
     }
 `

--- a/results/src/core/share/ShareLink.js
+++ b/results/src/core/share/ShareLink.js
@@ -74,6 +74,7 @@ const LinkWithLabel = styled(Button)`
     display: flex;
     justify-content: flex-start;
     align-items: center;
+    text-align: initial;
     &:hover {
         path,
         circle {


### PR DESCRIPTION
This issue is relevant for translations where the messages may be longer than the original ones.

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/146075711-6e867b15-bdce-4e94-9736-f83198204503.png) | ![image](https://user-images.githubusercontent.com/4408379/146075785-a9bd5b12-ea4c-45d5-a124-17efd344a923.png) |