### PR TITLE
Fix fatal error when invalid URL of entity

### DIFF
--- a/results/src/core/blocks/block/BlockLinks.js
+++ b/results/src/core/blocks/block/BlockLinks.js
@@ -40,13 +40,24 @@ const Link = styled(Button)`
 `
 
 const getDomain = url => {
-    const { hostname } = new URL(url)
-    return hostname
+    try {
+        const { hostname } = new URL(url)
+        return hostname
+    } catch (error) {
+        console.log(`// BlockLinks: invalid url ${url}`)
+        console.log(error)
+        return undefined;
+    }
 }
 
 const BlockLink = ({ id, label, url, icon }) => {
     const Icon = icon
     const label_ = id === 'homepage' ? getDomain(url) : label
+    
+    if (!label_) {
+        return null;
+    }
+    
     return (
         <Item>
             <Link as="a" href={url} title={id}>


### PR DESCRIPTION
Although this is a problem in the entity data (btw, I [made the fix](https://github.com/StateOfJS/entities/pull/1) for the case shown below), it is still a good thing to handle such a case.

Before:

![ezgif com-gif-maker (16)](https://user-images.githubusercontent.com/4408379/146076709-7cf73f3f-cb95-48f4-982b-79f40b28e592.gif)

After:

![image](https://user-images.githubusercontent.com/4408379/146076780-949adc97-2952-40bc-8c93-f0a596c226fc.png)

