### PR TITLE
Add correct minimum width for map on mobile

### DIFF
--- a/results/src/core/blocks/demographics/ParticipationByCountryBlock.js
+++ b/results/src/core/blocks/demographics/ParticipationByCountryBlock.js
@@ -31,9 +31,9 @@ const ParticipationByCountryBlock = ({
             block={block}
             completion={data.completion}
         >
-            <ChartContainer height={600}>
+            <ChartContainer height={600} minWidth={800}>
                 <div
-                    style={{ height: '100%' }}
+                    style={{ height: '100%', overflow: 'hidden' }}
                     className={`ParticipationByCountryChart ${chartClassName}`}
                 >
                     <ParticipationByCountryChart units={units} data={buckets} />

--- a/results/src/core/charts/ChartContainer.tsx
+++ b/results/src/core/charts/ChartContainer.tsx
@@ -50,11 +50,12 @@ const MemoIndicator = memo(Indicator)
 
 /**
  * - Fit: fit to viewport width
- * - Expand: force a 600px width
+ * - Expand: force a 600px or props width
  */
 const ChartContainer = ({
     children,
     height,
+    minWidth = 600,
     fit = false,
     className = '',
     vscroll = false
@@ -63,7 +64,7 @@ const ChartContainer = ({
         <Container className="ChartContainer" style={{ height }}>
             <ChartContainerInner
                 className={`ChartContainerInner${!fit ? ' ChartContainerInner--expand' : ''}`}
-                style={{ height }}
+                style={{ height, minWidth: fit ? '' : minWidth }}
             >
                 {children}
             </ChartContainerInner>


### PR DESCRIPTION
This adds a new minWidth property to the chartContainer that the ParticipationByCountryBlock uses to make sure the full map is shown. Also includes a fix for the internal vertical scrollbar.