### PR TITLE
remove alt text from sponsor image due to duplication

### DIFF
--- a/results/src/core/blocks/block/sponsor_chart/SponsorCredit.tsx
+++ b/results/src/core/blocks/block/sponsor_chart/SponsorCredit.tsx
@@ -16,7 +16,7 @@ const SponsorCredit = ({ sponsor }) => {
                 trigger={
                     <SponsorLink href={link}>
                         <ImageWrapper>
-                            <Image src={avatarUrl} alt={`@${username}`} />
+                            <Image src={avatarUrl} alt='' />
                         </ImageWrapper>
                         <Username>
                             <UsernameInner>@{username}</UsernameInner>


### PR DESCRIPTION
This prevents the username from being read twice for both the headings and links. Because the username is already in the link, the image can have an empty alt attribute.