### PR TITLE
fix nav active page to match trailing slash

### DIFF
--- a/results/src/core/components/sidebar/Nav.js
+++ b/results/src/core/components/sidebar/Nav.js
@@ -1,4 +1,6 @@
 import React from 'react'
+import { useMatch } from "@reach/router"
+import get from 'lodash/get'
 import styled, { css } from 'styled-components'
 import sitemap from 'Config/raw_sitemap.yml'
 import { mq, fancyLinkMixin, spacing } from 'core/theme'
@@ -73,10 +75,14 @@ const NavItem = ({ page, parentPage, currentPath, closeSidebar, isHidden = false
     const hasChildren = page.children && page.children.length > 0
     const displayChildren = hasChildren > 0 && isActive
 
+    const match = useMatch(
+        `${get(usePageContext(), 'locale.path')}${parentPage?.path ?? ''}${page.path}`
+    )
+
     return (
         <>
             <StyledPageLink
-                activeClassName="_is-active"
+                className={match ? "_is-active" : undefined}
                 onClick={closeSidebar}
                 page={page}
                 depth={depth}


### PR DESCRIPTION
The sidebar nav links don't currently match paths with trailing slash, which is a problem because paths is the sitemap are generated with a trailing slash (not sure why: https://github.com/StateOfJS/Monorepo/blob/main/results/node_src/sitemap.js#L108). The result is that sidebar nav links don't display as active when following PaginationLinks.